### PR TITLE
QOL changes : Add easy way to fix IP and automatically adjust oset to instrument in GUI

### DIFF
--- a/GUI_viper.py
+++ b/GUI_viper.py
@@ -374,7 +374,8 @@ class GUI_viper:
         if file:
             e_file.delete(0, END)
             e_file.insert(0, file)
-
+            
+    # Define some parameters according to the chosen instrument (cell file, iset, oset, ...)
     def Update_inst(self):
         Inst = importlib.import_module('inst.inst_' + self.combo_inst.get())
          
@@ -387,6 +388,9 @@ class GUI_viper:
 
         self.e_iset.delete(0, END)
         self.e_iset.insert(0, getattr(Inst, 'iset', ':'))
+
+        self.e_oset.delete(0, END)
+        self.e_oset.insert(0, getattr(Inst, 'oset', ':'))
 
         # molecule selection for tellurics
         #self.molec = list(Inst.atmall.keys())

--- a/viper.py
+++ b/viper.py
@@ -536,6 +536,7 @@ def fit_chunk(order, chunk, obsname, targ=None, tpltarg=None):
         par.wave = parguess.wave   # why?
         # fix wavelength solution for stabilzied spectographs:
         if 'wave' in fix: par.wave = fixed(parguess.wave)
+        if 'ip' in fix: par.ip = fixed(par.ip)
         if ipB:
             par.bkg = [(0, 0)]
             par.ipB = [(ipB[0], 0)]


### PR DESCRIPTION
In the viper GUI : When selecting an instrument, automatically set the 'oset' to the value defined in that instrument's inst file. This allows to quickly see what orders are available for a given instrument.

In the viper.py file : Copied the line used for -fix wave, but for the IP. Allows the user to easily fix the IP if needed. 