### PR TITLE
[TO CLOSE WHEN READY] Add new convolution if template is already convolved with IP (and a few small things)

### DIFF
--- a/inst/inst_CARM_VIS.py
+++ b/inst/inst_CARM_VIS.py
@@ -100,17 +100,29 @@ def Tpl(tplname, order=None, targ=None):
             pixel, wavelen_k, spec_k, err_spec_k, flag_pixel, bjd, berv = Spectrum(tplname, order=order, targ=targ)
             '''SERVAL already applies barycentric correction to templates, so the line below can be removed'''
             #wavelen_k *= 1 + (berv*u.km/u.s/c).to_value('') # Apply barycentric correction
+            
+            # CubicSpline interpolation to artificially improve sampling in the template
+            wavelen = np.linspace(wavelen_k[0], wavelen_k[-1], 4*wavelen_k.size)    # Interpolate with 4 times as many points
+            spec = CubicSpline(wavelen_k, spec_k, bc_type='natural')(wavelen)   
+            wavelen = np.exp(wavelen) # Convert log knots to linear knots
         except:
-            print('Error : Barycentric correction for the selected template has failed.')
+            print('Error : Barycentric correction for the selected .fits template has failed.')
             exit()
+            
+    elif tplname.endswith('.all'):    # for PEPSI templates
+        try:
+            hdu = fits.open(tplname)
+            wavelen = hdu[1].data.field('Arg')
+            spec = hdu[1].data.field('Fun')
+            wavelen = airtovac(wavelen)    # convert the wavelength values from air to vacuum. Unlike SERVAL templates which already take this into account
+            
+        except:
+            print('Error : Barycentric correction for the selected .all template has failed.')
+            exit()
+            
     else:
-        print('\x1b[0;31;40m' +'Error: Template format is not known for the selected instrument. \nPlease select a .fits file'+ '\x1b[0m')    
+        print('\x1b[0;31;40m' +'Error: Template format is not known for the selected instrument. \nPlease select a .fits file or .all file'+ '\x1b[0m')    
         exit()
-    
-    # CubicSpline interpolation to artificially improve sampling in the template
-    wavelen = np.linspace(wavelen_k[0], wavelen_k[-1], 4*wavelen_k.size)    # Interpolate with 4 times as many points
-    spec = CubicSpline(wavelen_k, spec_k, bc_type='natural')(wavelen)   
-    wavelen = np.exp(wavelen) # Convert log knots to linear knots
     
     return wavelen, spec
 

--- a/inst/inst_CARM_VIS.py
+++ b/inst/inst_CARM_VIS.py
@@ -11,6 +11,7 @@ This file was written by Naïm Teriitehau-Martin. For any issues, please contact
 ''' THIS IS STILL A WORK IN PROGRESS as of 20/04/2026'''
 
 import numpy as np
+import os
 from astropy.io import fits
 from astropy.time import Time
 from astropy.coordinates import SkyCoord, EarthLocation
@@ -18,7 +19,7 @@ import astropy.units as u
 from astropy.constants import c
 from scipy.interpolate import CubicSpline
 
-# from inst.template import read_tpl   #### DO NOT NEED IF APPLY BARYCENTRIC CORRECTION IN THIS FILE?
+from inst.template import read_tpl
 from inst.FTS_resample import resample, FTSfits 
 from inst.airtovac import airtovac
 
@@ -68,7 +69,6 @@ def Spectrum(filename='', order=None, targ=None):
     wavelen = hdu['WAVE'].data    # Vacuum wavelength for each pixel [angstrom]
     err_spec = hdu['SIG'].data    # Error estimate for flux
     
-    
     # If specific order is selected, only keep that order
     if order is not None:
         wavelen, spec, err_spec = wavelen[order], spec[order], err_spec[order]
@@ -83,61 +83,10 @@ def Spectrum(filename='', order=None, targ=None):
 def Tpl(tplname, order=None, targ=None):
     '''
     Tpl should return barycentric corrected wavelengths.
-    read_tpl(tplname) tries to call Spectrum(tplname=template_file) from the indicated inst file and apply a
-    barycentric correction to the returned wavelen (if tplname doesn't end with "_tpl")
+    read_tpl(tplname) reads wavelen and flux from template ; applies necessary corrections depending on type of file (barycentric correc, vacuum correc, ...)
     '''
-    # Check if template already convolved with the IP (If yes, will need to apply a different convolution in utils/model.py) ;
-    # IMPORTANT REMARK : Currently it only checks if template comes from SERVAL (no idea how it could be generalized to other sources of templates)
-    hdr = fits.open(tplname, ignore_blank=True)[0].header
-    tpl_is_serval = 'HIERARCH SERVAL COADD NUM' in hdr    # all SERVAL templates contain this key to indicate number of spectra used for coadd, but none of the data files contain it
-    
-    global tpl_IP_isconv    # define as global so it can be called from other files
-    tpl_IP_isconv = tpl_is_serval    # currently it only actually checks if the template comes from SERVAL
-    
+    wavelen, spec = read_tpl(tplname, inst=os.path.basename(__file__), order=order, targ=targ)
 
-    if tplname.endswith('.fits'):
-        try:
-            pixel, wavelen_k, spec_k, err_spec_k, flag_pixel, bjd, berv = Spectrum(tplname, order=order, targ=targ)
-            
-            #SERVAL templates store flux and natural log of vacuum wavelen as the "knot positions of uniform B-spline" 
-            #so we need to apply cubic spline to get data between the knots, and convert to linear wavelen
-            if tpl_is_serval:
-                # CubicSpline interpolation to artificially improve sampling in the template
-                wavelen = np.linspace(wavelen_k[0], wavelen_k[-1], 4*wavelen_k.size)    # Interpolate with 4 times as many points
-                spec = CubicSpline(wavelen_k, spec_k, bc_type='natural')(wavelen)   
-                wavelen = np.exp(wavelen) # Convert log knots to linear knots
-                
-            # tpl_R = 91_000
-        except:
-            print('\x1b[0;31;40mError : Barycentric correction for the selected .fits template has failed. \x1b[0m')
-            exit()
-            
-    elif tplname.endswith('.all'):    # for PEPSI templates
-        try:
-            hdu = fits.open(tplname)
-            wavelen = hdu[1].data.field('Arg')  # Wavelengths for template spectrum
-            spec = hdu[1].data.field('Fun') # Flux for template spectrum
-            wavelen = airtovac(wavelen)    # convert the wavelength values from air to vacuum. Unlike SERVAL templates which already take this into account
-            
-            '''
-            Check if template is from serval using something like the lines below?
-            there was Also something like if the resolution of the tpl is high enough then do not convolve with IP???
-                
-            global tpl_has_IP
-            # tpl_R = 200_000
-            tpl_has_IP = True
-            spec.tpl_has_IP = True
-            '''
-        except:
-            print('\x1b[0;31;40mError : Barycentric correction for the selected .all template has failed. \x1b[0m')
-            exit()
-            
-    else:
-        print('\x1b[0;31;40m' +'Error: Template format is not known for the selected instrument. \nPlease select a .fits file or .all file'+ '\x1b[0m')    
-        exit()
-        
-    #flux
-    #spec = (wavelen, flux, R) reutrn dict ? would need to change the other inst files and viper.py
     return wavelen, spec
 
 

--- a/inst/inst_CARM_VIS.py
+++ b/inst/inst_CARM_VIS.py
@@ -8,7 +8,7 @@ This file was written by Naïm Teriitehau-Martin. For any issues, please contact
 """
 
 ###### CARM_VIS ######
-''' THIS IS A WORK IN PROGRESS '''
+''' THIS IS STILL A WORK IN PROGRESS as of 20/04/2026'''
 
 import numpy as np
 from astropy.io import fits
@@ -20,15 +20,14 @@ from scipy.interpolate import CubicSpline
 
 # from inst.template import read_tpl   #### DO NOT NEED IF APPLY BARYCENTRIC CORRECTION IN THIS FILE?
 from inst.FTS_resample import resample, FTSfits 
+from inst.airtovac import airtovac
 
-oset = '20:50'    # Relative orders that are analyzed (Here we keep only the 20th to 49th available orders, ) (for CARM_VIS, the absolute orders start at 118 [low wavlengths] and end at 58 [high wavelengths])
-iset='400:3600'    # Keep the pixels between X and Y ; Do not analyze the ones outside of that range -- Chosen arbitrarily and can be changed by the user
+oset = '20:50'    # Relative orders that are analyzed (Here we keep only the 20th to 50th available orders. For CARM_VIS, the absolute orders start at 118 [low wavlengths] and end at 58 [high wavelengths])
+iset='400:3600'    # Keep the pixels between X and Y ; Do not analyze the ones outside of that range -- Chosen arbitrarily and can be changed by the user (goes up to 0:4000)
+
 
 # Convert FWHM resolution to sigma
-''' The IP is currently set to a very low number, because CARMENES usually uses SERVAL templates, and those have the spectrum 
-of the star already convoluted with the IP. But the viper code tries to do another convolution, which we do not want.
-'''
-ip_guess = {'s' : 300_000/(588_94_600*2*np.sqrt(2*np.log(2)))}    # speed of light divided by (spectrograph_resolution x factor) -- Assuming Gaussian IP, FWHM defined in speed v
+ip_guess = {'s' : c.to_value(u.km/u.s)/(94_600*2*np.sqrt(2*np.log(2)))}  # speed of light [km/s] divided by (spectrograph_resolution x factor) -- Assuming Gaussian IP for factor ; FWHM is defined in terms of speed dv [km/s] (which is ~= delta(ln(wavelen)))
 
 # Location of CARMENES Spectrograph -- Obtained from the data headers (hdr keys 'HIERARCH CAHA TEL GEOLAT' and 'HIERARCH CAHA TEL GEOLON' and 'HIERARCH CAHA TEL GEOELEV')
 location = carmenes = EarthLocation.from_geodetic(lat=37.2236*u.deg, lon=-2.54625*u.deg, height=2168.*u.m)
@@ -42,14 +41,16 @@ def Spectrum(filename='', order=None, targ=None):
     #exptime = hdr.get('EXPTIME')    # Exposure time in seconds
     ''' HERE WE GET TMEAN FROM HEADERS (so it is an absolute value, also less reliable because it is in header)
     I HAVE TO FIND A WAY TO GET IT FROM THE serval DIR (which is the same as the CARMENES_templates btw) -- 
-    The problem being that I have to somehow call that file, which implies the user has the file and it is in the exact same path as how I call it'''
-    exptime_tmean = hdr.get('HIERARCH CARACAL TMEAN') * u.s  # Flux-weighted midpoint of exposure (more accurate than exptime)
+    The problem being that I have to somehow call that file, which implies the user has the file and it is in the exact same path as how I call it
+    
+    ---> In the meantime, just check if there is a file in the given path (path will automatically be generated, like I did in SCRIPT_checks_if_serval_in_hdr.py
+         and assuming that it is only used by people in the IAG intranet? And if no file found (ex. path not exist because used by external user) then just use hdr TMEAN?'''
+    exptime_tmean = hdr.get('HIERARCH CARACAL TMEAN') * u.s  # Flux-weighted midpoint of exposure (more accurate than the exptime)
 
     # If target not specified while calling Spectrum() : Define target from data file header info
     ra = hdr.get('RA', np.nan)     # RightAscension of target [degrees]
     dec = hdr.get('DEC', np.nan)    # Declination of target [degrees]
-    '''The line below seems to be necessary for some SERVAL templates'''
-    dec = (dec+90) % 180 - 90   #Declination needs to be between -90 and 90 deg, but headers give values way past that
+    dec = (dec+90) % 180 - 90   #Declination needs to be between -90 and 90 deg, but some SERVAL tpl headers give values way bigger than that so we fix it
     targdrs = SkyCoord(ra=ra*u.deg, dec=dec*u.deg)
     if not targ: targ = targdrs
     
@@ -65,7 +66,7 @@ def Spectrum(filename='', order=None, targ=None):
     # Read file data to obtain spec, wavelen, err
     spec = hdu['SPEC'].data    # Flux for spectrum
     wavelen = hdu['WAVE'].data    # Vacuum wavelength for each pixel [angstrom]
-    err_spec = hdu['SIG'].data    # Get error estimate for spec
+    err_spec = hdu['SIG'].data    # Error estimate for flux
     
     
     # If specific order is selected, only keep that order
@@ -79,51 +80,64 @@ def Spectrum(filename='', order=None, targ=None):
     return pixel, wavelen, spec, err_spec, flag_pixel, bjd, berv
 
 
-
 def Tpl(tplname, order=None, targ=None):
     '''
     Tpl should return barycentric corrected wavelengths.
     read_tpl(tplname) tries to call Spectrum(tplname=template_file) from the indicated inst file and apply a
     barycentric correction to the returned wavelen (if tplname doesn't end with "_tpl")
-    
-    Currently this only works with templates that store wavelen data as natural log wavelen (like the ones produced by serval)
-    Because the wavelen are converted into linear wavelen via np.exp()
     '''
+    # Check if template already convolved with the IP (If yes, will need to apply a different convolution in utils/model.py) ;
+    # IMPORTANT REMARK : Currently it only checks if template comes from SERVAL (no idea how it could be generalized to other sources of templates)
+    hdr = fits.open(tplname, ignore_blank=True)[0].header
+    tpl_is_serval = 'HIERARCH SERVAL COADD NUM' in hdr    # all SERVAL templates contain this key to indicate number of spectra used for coadd, but none of the data files contain it
     
+    global tpl_IP_isconv    # define as global so it can be called from other files
+    tpl_IP_isconv = tpl_is_serval    # currently it only actually checks if the template comes from SERVAL
     
-    '''
-    SERVAL templates store spec and natural log of vacuum wavelen as the "knot positions of uniform B-spline"
-    so we need to convert to linear wavelen then apply cubic spline to get data between the knots
-    '''
-    if tplname.endswith('.fits'):   #The only type of SERVAL template I am aware of
+
+    if tplname.endswith('.fits'):
         try:
             pixel, wavelen_k, spec_k, err_spec_k, flag_pixel, bjd, berv = Spectrum(tplname, order=order, targ=targ)
-            '''SERVAL already applies barycentric correction to templates, so the line below can be removed'''
-            #wavelen_k *= 1 + (berv*u.km/u.s/c).to_value('') # Apply barycentric correction
             
-            # CubicSpline interpolation to artificially improve sampling in the template
-            wavelen = np.linspace(wavelen_k[0], wavelen_k[-1], 4*wavelen_k.size)    # Interpolate with 4 times as many points
-            spec = CubicSpline(wavelen_k, spec_k, bc_type='natural')(wavelen)   
-            wavelen = np.exp(wavelen) # Convert log knots to linear knots
+            #SERVAL templates store flux and natural log of vacuum wavelen as the "knot positions of uniform B-spline" 
+            #so we need to apply cubic spline to get data between the knots, and convert to linear wavelen
+            if tpl_is_serval:
+                # CubicSpline interpolation to artificially improve sampling in the template
+                wavelen = np.linspace(wavelen_k[0], wavelen_k[-1], 4*wavelen_k.size)    # Interpolate with 4 times as many points
+                spec = CubicSpline(wavelen_k, spec_k, bc_type='natural')(wavelen)   
+                wavelen = np.exp(wavelen) # Convert log knots to linear knots
+                
+            # tpl_R = 91_000
         except:
-            print('Error : Barycentric correction for the selected .fits template has failed.')
+            print('\x1b[0;31;40mError : Barycentric correction for the selected .fits template has failed. \x1b[0m')
             exit()
             
     elif tplname.endswith('.all'):    # for PEPSI templates
         try:
             hdu = fits.open(tplname)
-            wavelen = hdu[1].data.field('Arg')
-            spec = hdu[1].data.field('Fun')
+            wavelen = hdu[1].data.field('Arg')  # Wavelengths for template spectrum
+            spec = hdu[1].data.field('Fun') # Flux for template spectrum
             wavelen = airtovac(wavelen)    # convert the wavelength values from air to vacuum. Unlike SERVAL templates which already take this into account
             
+            '''
+            Check if template is from serval using something like the lines below?
+            there was Also something like if the resolution of the tpl is high enough then do not convolve with IP???
+                
+            global tpl_has_IP
+            # tpl_R = 200_000
+            tpl_has_IP = True
+            spec.tpl_has_IP = True
+            '''
         except:
-            print('Error : Barycentric correction for the selected .all template has failed.')
+            print('\x1b[0;31;40mError : Barycentric correction for the selected .all template has failed. \x1b[0m')
             exit()
             
     else:
         print('\x1b[0;31;40m' +'Error: Template format is not known for the selected instrument. \nPlease select a .fits file or .all file'+ '\x1b[0m')    
         exit()
-    
+        
+    #flux
+    #spec = (wavelen, flux, R) reutrn dict ? would need to change the other inst files and viper.py
     return wavelen, spec
 
 
@@ -134,16 +148,13 @@ def FTS(ftsname='None', dv=100):
     Converts wavenumbers [cm] to wavelengths (w) [angstrom], also inverts w and f arrays ( [::-1] ) so that wavelengths are in ascending order
     resample() returns w, f, uj= np.arange(ln(w)) with step dv/c, iod_j=flux interpolated from uj
     '''
-    print('fts was called')
     return resample(*FTSfits(ftsname), dv=dv)
 
 
 
 # If we want to create a template
 def write_fits(wtpl_all, tpl_all, e_all, list_files, file_out):
-    print(' nuh uh write fit')
-    
-    
+
     # Get data from header of the first fits file
     file_in = list_files[0]
     hdu = fits.open(file_in, ignore_blank=True)

--- a/inst/inst_CES.py
+++ b/inst/inst_CES.py
@@ -71,6 +71,12 @@ def Spectrum(filename, order=None, targ=None, chksize=4000):
     return x, w, f, e_f, b, bjd, berv
 
 def Tpl(tplname, order=None, targ=None):
+    
+    # Check if template already convolved with the IP (If yes, will need to apply a different convolution in utils/model.py) ;
+    # Currently not applied to this instrument ; will need to add in the future if required
+    global tpl_IP_isconv    # define as global so it can be called from other files
+    tpl_IP_isconv = False    # Insert some condition to check if True or False (e.g. check inst/CARM_VIS.py)
+    
     if tplname.endswith('.dat'):
         # echelle template
         x, w, f, e, b, bjd, berv = Spectrum(tplname, targ=targ)

--- a/inst/inst_CRIRES.py
+++ b/inst/inst_CRIRES.py
@@ -163,6 +163,11 @@ def Spectrum(filename='', order=None, targ=None):
 def Tpl(tplname, order=None, targ=None):
     '''Tpl should return barycentric corrected wavelengths'''
 
+    # Check if template already convolved with the IP (If yes, will need to apply a different convolution in utils/model.py) ;
+    # Currently not applied to this instrument ; will need to add in the future if required
+    global tpl_IP_isconv    # define as global so it can be called from other files
+    tpl_IP_isconv = False    # Insert some condition to check if True or False (e.g. check inst/CARM_VIS.py)
+
     if tplname.endswith('_tpl.fits'):
         # tpl created with viper
         

--- a/inst/inst_DEFAULT.py
+++ b/inst/inst_DEFAULT.py
@@ -68,6 +68,12 @@ def Spectrum(filename='', order=None, targ=None):
 
 def Tpl(tplname, order=None, targ=None):
     '''Tpl should return barycentric corrected wavelengths'''
+
+    # Check if template already convolved with the IP (If yes, will need to apply a different convolution in utils/model.py) ;
+    # Currently not applied to this instrument ; will need to add in the future if required
+    global tpl_IP_isconv    # define as global so it can be called from other files
+    tpl_IP_isconv = False    # Insert some condition to check if True or False (e.g. check inst/CARM_VIS.py)
+    
     wave, spec = read_tpl(tplname, inst=os.path.basename(__file__), order=order, targ=targ) 
 
     return wave, spec

--- a/inst/inst_ESPRESSO.py
+++ b/inst/inst_ESPRESSO.py
@@ -68,6 +68,11 @@ def Spectrum(filename='', order=None, targ=None):
 def Tpl(tplname, order=None, targ=None):
     '''Tpl should return barycentric corrected wavelengths'''
 
+    # Check if template already convolved with the IP (If yes, will need to apply a different convolution in utils/model.py) ;
+    # Currently not applied to this instrument ; will need to add in the future if required
+    global tpl_IP_isconv    # define as global so it can be called from other files
+    tpl_IP_isconv = False    # Insert some condition to check if True or False (e.g. check inst/CARM_VIS.py)
+
     wave, spec = read_tpl(tplname, inst=os.path.basename(__file__), order=order, targ=targ)
 
     return wave, spec

--- a/inst/inst_GIANO.py
+++ b/inst/inst_GIANO.py
@@ -48,6 +48,11 @@ def Spectrum(filename='', order=None, targ=None):
 
 def Tpl(tplname, order=None, targ=None):
     '''Tpl should return barycentric corrected wavelengths'''
+
+    # Check if template already convolved with the IP (If yes, will need to apply a different convolution in utils/model.py) ;
+    # Currently not applied to this instrument ; will need to add in the future if required
+    global tpl_IP_isconv    # define as global so it can be called from other files
+    tpl_IP_isconv = False    # Insert some condition to check if True or False (e.g. check inst/CARM_VIS.py)
     
     wave, spec = read_tpl(tplname, inst=os.path.basename(__file__), order=order, targ=targ)
 

--- a/inst/inst_KECK.py
+++ b/inst/inst_KECK.py
@@ -98,6 +98,11 @@ def Spectrum(filename, order=None, targ=None):
 
 def Tpl(tplname, order=None, targ=None):
     '''Tpl should return barycentric corrected wavelengths'''
+
+    # Check if template already convolved with the IP (If yes, will need to apply a different convolution in utils/model.py) ;
+    # Currently not applied to this instrument ; will need to add in the future if required
+    global tpl_IP_isconv    # define as global so it can be called from other files
+    tpl_IP_isconv = False    # Insert some condition to check if True or False (e.g. check inst/CARM_VIS.py)
     
     wave, spec = read_tpl(tplname, inst=os.path.basename(__file__), order=order, targ=targ)
 

--- a/inst/inst_McDonald.py
+++ b/inst/inst_McDonald.py
@@ -62,6 +62,11 @@ def Spectrum(filename='', order=None, targ=None):
 
 def Tpl(tplname, order=None, targ=None):
     '''Tpl should return barycentric corrected wavelengths'''
+
+    # Check if template already convolved with the IP (If yes, will need to apply a different convolution in utils/model.py) ;
+    # Currently not applied to this instrument ; will need to add in the future if required
+    global tpl_IP_isconv    # define as global so it can be called from other files
+    tpl_IP_isconv = False    # Insert some condition to check if True or False (e.g. check inst/CARM_VIS.py)
     
     wave, spec = read_tpl(tplname, inst=os.path.basename(__file__), order=order, targ=targ)
 

--- a/inst/inst_OES.py
+++ b/inst/inst_OES.py
@@ -71,6 +71,11 @@ def Spectrum(filename='', order=None, targ=None):
 def Tpl(tplname, order=None, targ=None):
     '''Tpl should return barycentric corrected wavelengths'''
     
+    # Check if template already convolved with the IP (If yes, will need to apply a different convolution in utils/model.py) ;
+    # Currently not applied to this instrument ; will need to add in the future if required
+    global tpl_IP_isconv    # define as global so it can be called from other files
+    tpl_IP_isconv = False    # Insert some condition to check if True or False (e.g. check inst/CARM_VIS.py)
+    
     wave, spec = read_tpl(tplname, inst=os.path.basename(__file__), order=order, targ=targ)
     
     return wave, spec

--- a/inst/inst_PUCHEROS.py
+++ b/inst/inst_PUCHEROS.py
@@ -68,6 +68,11 @@ def Spectrum(filename='', order=None, targ=None):
 
 def Tpl(tplname, order=None, targ=None):
     '''Tpl should return barycentric corrected wavelengths'''
+	
+	# Check if template already convolved with the IP (If yes, will need to apply a different convolution in utils/model.py) ;
+    # Currently not applied to this instrument ; will need to add in the future if required
+    global tpl_IP_isconv    # define as global so it can be called from other files
+    tpl_IP_isconv = False    # Insert some condition to check if True or False (e.g. check inst/CARM_VIS.py)
 
     if tplname.endswith('1d.fits') and not tplname.endswith('_s1d.fits'):
         hdu = fits.open(tplname, ignore_blank=True)[0]

--- a/inst/inst_PlatoSpec.py
+++ b/inst/inst_PlatoSpec.py
@@ -83,6 +83,11 @@ def Spectrum(filename='', order=None, targ=None):
 
 def Tpl(tplname, order=None, targ=None):
     '''Tpl should return barycentric corrected wavelengths'''
+
+    # Check if template already convolved with the IP (If yes, will need to apply a different convolution in utils/model.py) ;
+    # Currently not applied to this instrument ; will need to add in the future if required
+    global tpl_IP_isconv    # define as global so it can be called from other files
+    tpl_IP_isconv = False    # Insert some condition to check if True or False (e.g. check inst/CARM_VIS.py)
     
     wave, spec = read_tpl(tplname, inst=os.path.basename(__file__), order=order, targ=targ) 
 

--- a/inst/inst_TLS.py
+++ b/inst/inst_TLS.py
@@ -77,6 +77,11 @@ def Spectrum(filename='data/TLS/other/BETA_GEM.fits', order=None, targ=None):
 
 def Tpl(tplname, order=None, targ=None):
     '''Tpl should return barycentric corrected wavelengths'''
+
+    # Check if template already convolved with the IP (If yes, will need to apply a different convolution in utils/model.py) ;
+    # Currently not applied to this instrument ; will need to add in the future if required
+    global tpl_IP_isconv    # define as global so it can be called from other files
+    tpl_IP_isconv = False    # Insert some condition to check if True or False (e.g. check inst/CARM_VIS.py)
     
     wave, spec = read_tpl(tplname, inst=os.path.basename(__file__), order=order, targ=targ) 
 

--- a/inst/inst_TRES.py
+++ b/inst/inst_TRES.py
@@ -70,6 +70,11 @@ def Spectrum(filename='', order=None, targ=None):
 
 def Tpl(tplname, order=None, targ=None):
     '''Tpl should return barycentric corrected wavelengths'''
+
+    # Check if template already convolved with the IP (If yes, will need to apply a different convolution in utils/model.py) ;
+    # Currently not applied to this instrument ; will need to add in the future if required
+    global tpl_IP_isconv    # define as global so it can be called from other files
+    tpl_IP_isconv = False    # Insert some condition to check if True or False (e.g. check inst/CARM_VIS.py)
     
     wave, spec = read_tpl(tplname, inst=os.path.basename(__file__), order=order, targ=targ) 
 

--- a/inst/inst_UVES.py
+++ b/inst/inst_UVES.py
@@ -83,6 +83,11 @@ def Spectrum(filename, order=None, targ=None):
 
 def Tpl(tplname, order=None, targ=None):
     '''Tpl should return barycentric corrected wavelengths'''
+    # Check if template already convolved with the IP (If yes, will need to apply a different convolution in utils/model.py) ;
+    # Currently not applied to this instrument ; will need to add in the future if required
+    global tpl_IP_isconv    # define as global so it can be called from other files
+    tpl_IP_isconv = False    # Insert some condition to check if True or False (e.g. check inst/CARM_VIS.py)
+    
     if tplname.endswith('_tpl.fits'):
         hdu = fits.open(tplname)[1]
         #from pause import pause; pause()

--- a/inst/template.py
+++ b/inst/template.py
@@ -7,16 +7,18 @@ import importlib
 import astropy.units as u
 from astropy.constants import c
 from astropy.io import fits
-from .airtovac import airtovac
+from inst.airtovac import airtovac
 
 
-def read_tpl(tplname, inst='inst_TLS.py', order=20, targ='None', wmin=3500, wmax=8000):
-
+def read_tpl(tplname, inst='inst_TLS.py', order=20, targ=None, wmin=3500, wmax=8000):
     successful_read = 0
     
     hdu = fits.open(tplname, ignore_blank=True, output_verify='silentfix')
     hdr = hdu[0].header
     p3orig = hdr.get('P3ORIG', 'none')
+    
+    # True or False : template is already convolved with IP. Changes how convolution is applied in the model. Called in viper.py ; False by default
+    global tpl_has_IP # defined as global so it can be called from other files
 
     if str(p3orig) == 'IDP':
         # direct read-in of spectra with ESO phase-3 format
@@ -28,6 +30,7 @@ def read_tpl(tplname, inst='inst_TLS.py', order=20, targ='None', wmin=3500, wmax
         wave = airtovac(wave)
         
         successful_read = 1
+    
     
     elif tplname.endswith('_s1d_A.fits') or tplname.endswith('.tpl.s1d.fits'):
         print('read HARPS template', tplname)
@@ -42,20 +45,30 @@ def read_tpl(tplname, inst='inst_TLS.py', order=20, targ='None', wmin=3500, wmax
             wave = np.exp(wave)
         successful_read = 1
     
+    
     elif tplname.endswith('.fits') or tplname.endswith('.model'):
-       
+
         try:
           #  print('read '+inst.split('.')[0][5:]+' template', tplname)
             inst = importlib.import_module('inst.'+str(inst)[:-3])
-                       
             pixel, wave, spec, err, flag_pixel, bjd, berv = inst.Spectrum(tplname, order=order, targ=targ)
+                            
             if not tplname.endswith('_tpl.model') or not tplname.endswith('_tpl.fits'):
-                # apply barycentric correction
-                wave *= 1 + (berv*u.km/u.s/c).to_value('')
+                
+                #SERVAL templates store flux and natural log of vacuum wavelen as the "knot positions of uniform B-spline"
+                tpl_is_serval = 'HIERARCH SERVAL COADD NUM' in hdr    # all SERVAL templates contain this key to indicate number of spectra used for coadd
+                tpl_has_IP = tpl_is_serval    # for .fits files : currently it only actually checks if the template comes from SERVAL
+                if tpl_is_serval:
+                    #SERVAL templates are already barycentric and vacuum corrected. They store log wavelengths
+                    wave = np.exp(wave) # Convert log knots to linear knots    
+                else:
+                    # apply barycentric correction
+                    wave *= 1 + (berv*u.km/u.s/c).to_value('')
+                
             successful_read = 1
         except:
             pass        
-            
+        
         if not successful_read:        
             try:
                # long 1d template
@@ -66,6 +79,18 @@ def read_tpl(tplname, inst='inst_TLS.py', order=20, targ='None', wmin=3500, wmax
                 successful_read = 1
             except:
                 pass
+
+
+    elif tplname.endswith('.dxt.all*'):    # for PEPSI templates
+        try:
+            wave = hdu[1].data.field('Arg')  # Wavelengths from template spectrum
+            spec = hdu[1].data.field('Fun') # Flux from template spectrum
+            wave = airtovac(wave)
+            successful_read = 1
+        except:
+            pass  
+    
+
 
     elif 'PHOENIX' in str(tplname):
         '''

--- a/utils/model.py
+++ b/utils/model.py
@@ -202,39 +202,6 @@ class model:
             g = self.lnwave_j_eff - self.lnwave_j_eff[0]
             g /= g[-1]
             Sj_eff = (1-g)*Sj_A + g*Sj_B
-        
-        ''' 
-        CARMENES uses the SERVAL templates which require a different convolution. The plan is to generalize this later 
-        so that the convolution is done differently if it is a SERVAL template and not just if it is a CARMENES observation.
-        '''
-        '''
-        # if star spectrum is already convolved with IP (true for SERVAL templates) : approximate the convolution (written "*") as (a x b)*c ~= (a*c) x (b*c) (see  E. Nagel et al. 2023, A&A, 680, A73)
-        if self.tpl_IP_isconv == ('CARM_VIS' or 'CARM_NIR'): 
-            print(f'DOING THE THING WITH {self.tpl_IP_isconv} and STATEMENT {self.tpl_IP_isconv == ("CARM_VIS" or "CARM_NIR")}')
-            print('CHANGE THIS so that it checks if SERVAL template instead')
-            # the convolution np.conv(mode='valid') trims the edges of spec_gas by half of len(self.IP) on either side : so we use S_star(lnwave_j_eff) instead of S_star(lnwave_j) to trim edges of S_star by the same amount
-            Sj_eff = self.S_star(self.lnwave_j_eff-rv/c) * np.convolve(self.IP(self.vk, *coeff_ip), (spec_gas + coeff_bkg[0]), mode='valid')
-            print('DONE THE THING')
-            # if ipB is entered (=factor of IP width variation) : coeff_ipB = multiply IP width (coeff.ip) by ipB ; and use that instead of coeff_ip
-            if len(coeff_ipB):
-                coeff_ipB = [coeff_ipB[0]*coeff_ip[0], *coeff_ip[1:]]
-                Sj_B = self.S_star(self.lnwave_j_eff-rv/c)[self.IP_hs:-self.IP_hs] * np.convolve(self.IP(self.vk, *coeff_ipB), (spec_gas + coeff_bkg[0]), mode='valid')
-                Sj_A = Sj_eff
-                g = self.lnwave_j_eff - self.lnwave_j_eff[0]
-                g /= g[-1]  # normalization? since g is increasing ; g=1 for maximal separation (lnwave_j_eff[-1] - lnwave_j_eff[0])
-                Sj_eff = (1-g)*Sj_A + g*Sj_B
-           
-        else:   
-            # regular convolution as described in E. Koehler et al. 2025, A&A, 698, A44
-            Sj_eff = np.convolve(self.IP(self.vk, *coeff_ip), self.S_star(self.lnwave_j-rv/c) * (spec_gas + coeff_bkg[0]), mode='valid')
-            if len(coeff_ipB):
-                coeff_ipB = [coeff_ipB[0]*coeff_ip[0], *coeff_ip[1:]]
-                Sj_B = np.convolve(self.IP(self.vk, *coeff_ipB), self.S_star(self.lnwave_j-rv/c) * (spec_gas + coeff_bkg[0]), mode='valid')
-                Sj_A = Sj_eff
-                g = self.lnwave_j_eff - self.lnwave_j_eff[0]
-                g /= g[-1]
-                Sj_eff = (1-g)*Sj_A + g*Sj_B
-            '''
 
         # wavelength relation
         #    lam(x) = b0 + b1 * x + b2 * x^2

--- a/utils/model.py
+++ b/utils/model.py
@@ -132,27 +132,49 @@ def pade(x, a, b):
     return y
 
 
+
+def convolution(S_star, func_IP, T_cell_atm, tpl_IP_isconv=False, IP_hs=50):
+    '''
+    Convolution with the IP as described in equation (7) of E. Koehler et al. 2025, A&A, 698, A44. 
+    However : if star spectrum is already convolved with IP (true for SERVAL templates) : we do not want to convolve it again
+    so we approximate the convolution (written "*") as (a x b)*c ~= (a*c) x (b*c) (see appendix A of E. Nagel et al. 2023, A&A, 680, A73)
+    '''
+    if not tpl_IP_isconv:   # if tpl not convolved with IP : Apply regular convolution
+        Sj_eff = np.convolve(func_IP, S_star * T_cell_atm, mode='valid')
+
+    #if tpl already convolved with IP (eg. during template creation by coadding observation spectra): Take S_star out of convolution with IP 
+    elif tpl_IP_isconv: 
+        Sj_eff = S_star[IP_hs:-IP_hs] * np.convolve(func_IP, T_cell_atm, mode='valid')
+        #the convolution np.conv(mode='valid') trims the edges of the largest array (removes as many data points as there are in the smallest array -- see numpy documentation). 
+        #here it trims [len(func_IP) = IP_hs] data points on either side of T_cell_atm (which has same length as S_star) : so we trim S_star the same way to be able to multiply it with the convolution
+    
+    return Sj_eff
+
+
 class model:
     '''
     The forward model.
 
     '''
-    def __init__(self, *args, func_norm=poly, IP_hs=50, xcen=0):
+    def __init__(self, *args, func_norm=poly, IP_hs=50, xcen=0, tpl_IP_isconv=False):
         # IP_hs: Half size of the IP (number of sampling knots).
         # xcen: Central pixel (to center polynomial for numeric reason).
-
         self.xcen = xcen
         self.S_star, self.lnwave_j, self.spec_cell_j, self.fluxes_molec, self.IP = args
         # convolving with IP will reduce the valid wavelength range
-        self.dx = self.lnwave_j[1] - self.lnwave_j[0]   # step size of the uniform sampled grid
+        self.dx = self.lnwave_j[1] - self.lnwave_j[0]   # step size of the uniform sampled grid (wavelength)
         self.IP_hs = IP_hs
-        self.vk = np.arange(-IP_hs, IP_hs+1) * self.dx * c
+        self.vk = np.arange(-IP_hs, IP_hs+1) * self.dx * c    # position of sampling knots for the IP (expressed as speed)
         self.lnwave_j_eff = self.lnwave_j[IP_hs:-IP_hs]    # valid grid
         self.func_norm = func_norm
+        self.tpl_IP_isconv = tpl_IP_isconv
         #print("sampling [km/s]:", self.dx*c)
+        
+
 
     def __call__(self, pixel, rv=0, norm=[1], wave=[], ip=[], atm=[], bkg=[0], ipB=[]):
         # renaming (coeff is ok prefix below, but too verbose for par)
+        #the arguments of this function are the parameters (ip = par.ip, wave = par.wave, ...)
         coeff_norm, coeff_wave, coeff_ip, coeff_atm, coeff_bkg, coeff_ipB = norm, wave, ip, atm, bkg, ipB
 
         spec_gas = 1 * self.spec_cell_j
@@ -167,12 +189,12 @@ class model:
 
             spec_gas *= flux_atm
 
-        # IP convolution
-        Sj_eff = np.convolve(self.IP(self.vk, *coeff_ip), self.S_star(self.lnwave_j-rv/c) * (spec_gas + coeff_bkg[0]), mode='valid')
 
+        # apply IP convolution
+        Sj_eff = convolution(S_star=self.S_star(self.lnwave_j-rv/c), func_IP=self.IP(self.vk, *coeff_ip), T_cell_atm=(spec_gas + coeff_bkg[0]), tpl_IP_isconv=self.tpl_IP_isconv, IP_hs=self.IP_hs)
         if len(coeff_ipB):
             coeff_ipB = [coeff_ipB[0]*coeff_ip[0], *coeff_ip[1:]]
-            Sj_B = np.convolve(self.IP(self.vk, *coeff_ipB), self.S_star(self.lnwave_j-rv/c) * (spec_gas + coeff_bkg[0]), mode='valid')
+            Sj_B =convolution(S_star=self.S_star(self.lnwave_j-rv/c), func_IP=self.IP(self.vk, *coeff_ipB), T_cell_atm=(spec_gas + coeff_bkg[0]), tpl_IP_isconv=self.tpl_IP_isconv, IP_hs=self.IP_hs)
             Sj_A = Sj_eff
             g = self.lnwave_j_eff - self.lnwave_j_eff[0]
             g /= g[-1]
@@ -184,11 +206,12 @@ class model:
 
         # sampling to pixel
         Si_eff = np.interp(lnwave_obs, self.lnwave_j_eff, Sj_eff)
-
+        
         # flux normalisation
         Si_mod = self.func_norm(pixel-self.xcen, coeff_norm) * Si_eff
         #Si_mod = self.func_norm((np.exp(lnwave_obs)-b[0]-coeff_norm[-1]), coeff_norm[:-1]) * Si_eff
         return Si_mod
+
 
     def fit(self, pixel, spec_obs, par, sig=[], **kwargs):
         '''
@@ -198,18 +221,17 @@ class model:
 
         S_model = lambda x, *params: self(x, **(par + dict(zip(varykeys, params))))
         #S_model(pixel, *varyvals)
-
+        
         params, e_params = curve_fit(S_model, pixel, spec_obs, p0=varyvals, sigma=sig, absolute_sigma=False, epsfcn=1e-12)
-
         pnew = par + dict(zip(varykeys, params))
         # attach uncertainties
         for k, v in zip(varykeys, np.sqrt(np.diag(e_params))):
             pnew[k].unc = v
-
         if kwargs:
+            pass
             self.show(pnew, pixel, spec_obs, par_rv=pnew.rv, **kwargs)
-
         return pnew, e_params
+
 
     def show(self, params, x, y, par_rv=None, res=True, x2=None, dx=None, rel_fac=None):
         '''
@@ -222,8 +244,8 @@ class model:
         if x2 is None:
             x2 = np.poly1d(params.wave[::-1])(x-self.xcen)
         if par_rv:
+            pass
             gplot.RV2title(", v=%.2f ± %.2f m/s" % (par_rv*1000, par_rv.unc*1000))
-
         gplot.put("if (!exists('lam')) {lam=1}")
 
         gplot.key('horizontal')
@@ -232,7 +254,7 @@ class model:
         # toggle between pixel and wavelength with shortcut "$"
         gplot.bind('"$" "lam=!lam; set xlabel lam?\\"Vacuum wavelength [Å]\\":\\"Pixel x\\"; replot"')
         args = (x, y, ymod, x2, 'us lam?4:1:2:3 w lp pt 7 ps 0.5 t "obs",',
-          '"" us lam?4:1:3 w p pt 6 ps 0.5 lc 3 t "model"')
+          '"" us lam?4:1:3 w p pt 6 ps 0.5 lc 3 t "model"')    # add to the plot : x=pixels, y=observation flux, ymod=fitted flux model, x2 = wavelen
         prms = np.nan   # percentage prms
         if dx:
             xx = np.arange(x.min(), x.max(), dx)
@@ -240,7 +262,7 @@ class model:
             yymod = self(xx, **params)
             args += (",", xx, yymod, xx2, 'us lam?3:1:2 w l lc 3 t ""')
         if res or rel_fac:
-            # linear or relative residuals
+            # col2 is linear (if res) or relative (if rel_fac) residuals
             col2 = rel_fac * np.mean(ymod) * (y/ymod - 1) if rel_fac else y - ymod
             rms = np.std(col2)
             prms = rms / np.mean(ymod) * 100
@@ -249,7 +271,6 @@ class model:
             args += (",", x, col2, x2, "us lam?3:1:2 w p pt 7 ps 0.5 lc 1 t 'res (%.3g \~ %.3g%%)', 0 lc 3 t ''" % (rms, prms))
         if rel_fac:
             args += (",", x, col2, x2, "us lam?3:1:2 w l lc 1 t 'res (%.3g \~ %.3g%%)', 0 lc 3 t ''" % (rms, prms))
-
         if res or rel_fac or dx:
             gplot.yrange("[:%g]" % (1.4*np.nanmax(ymod)))
             gplot(*args)

--- a/utils/model.py
+++ b/utils/model.py
@@ -202,6 +202,39 @@ class model:
             g = self.lnwave_j_eff - self.lnwave_j_eff[0]
             g /= g[-1]
             Sj_eff = (1-g)*Sj_A + g*Sj_B
+        
+        ''' 
+        CARMENES uses the SERVAL templates which require a different convolution. The plan is to generalize this later 
+        so that the convolution is done differently if it is a SERVAL template and not just if it is a CARMENES observation.
+        '''
+        '''
+        # if star spectrum is already convolved with IP (true for SERVAL templates) : approximate the convolution (written "*") as (a x b)*c ~= (a*c) x (b*c) (see  E. Nagel et al. 2023, A&A, 680, A73)
+        if self.tpl_IP_isconv == ('CARM_VIS' or 'CARM_NIR'): 
+            print(f'DOING THE THING WITH {self.tpl_IP_isconv} and STATEMENT {self.tpl_IP_isconv == ("CARM_VIS" or "CARM_NIR")}')
+            print('CHANGE THIS so that it checks if SERVAL template instead')
+            # the convolution np.conv(mode='valid') trims the edges of spec_gas by half of len(self.IP) on either side : so we use S_star(lnwave_j_eff) instead of S_star(lnwave_j) to trim edges of S_star by the same amount
+            Sj_eff = self.S_star(self.lnwave_j_eff-rv/c) * np.convolve(self.IP(self.vk, *coeff_ip), (spec_gas + coeff_bkg[0]), mode='valid')
+            print('DONE THE THING')
+            # if ipB is entered (=factor of IP width variation) : coeff_ipB = multiply IP width (coeff.ip) by ipB ; and use that instead of coeff_ip
+            if len(coeff_ipB):
+                coeff_ipB = [coeff_ipB[0]*coeff_ip[0], *coeff_ip[1:]]
+                Sj_B = self.S_star(self.lnwave_j_eff-rv/c)[self.IP_hs:-self.IP_hs] * np.convolve(self.IP(self.vk, *coeff_ipB), (spec_gas + coeff_bkg[0]), mode='valid')
+                Sj_A = Sj_eff
+                g = self.lnwave_j_eff - self.lnwave_j_eff[0]
+                g /= g[-1]  # normalization? since g is increasing ; g=1 for maximal separation (lnwave_j_eff[-1] - lnwave_j_eff[0])
+                Sj_eff = (1-g)*Sj_A + g*Sj_B
+           
+        else:   
+            # regular convolution as described in E. Koehler et al. 2025, A&A, 698, A44
+            Sj_eff = np.convolve(self.IP(self.vk, *coeff_ip), self.S_star(self.lnwave_j-rv/c) * (spec_gas + coeff_bkg[0]), mode='valid')
+            if len(coeff_ipB):
+                coeff_ipB = [coeff_ipB[0]*coeff_ip[0], *coeff_ip[1:]]
+                Sj_B = np.convolve(self.IP(self.vk, *coeff_ipB), self.S_star(self.lnwave_j-rv/c) * (spec_gas + coeff_bkg[0]), mode='valid')
+                Sj_A = Sj_eff
+                g = self.lnwave_j_eff - self.lnwave_j_eff[0]
+                g /= g[-1]
+                Sj_eff = (1-g)*Sj_A + g*Sj_B
+            '''
 
         # wavelength relation
         #    lam(x) = b0 + b1 * x + b2 * x^2

--- a/utils/model.py
+++ b/utils/model.py
@@ -138,6 +138,9 @@ def convolution(S_star, func_IP, T_cell_atm, tpl_IP_isconv=False, IP_hs=50):
     Convolution with the IP as described in equation (7) of E. Koehler et al. 2025, A&A, 698, A44. 
     However : if star spectrum is already convolved with IP (true for SERVAL templates) : we do not want to convolve it again
     so we approximate the convolution (written "*") as (a x b)*c ~= (a*c) x (b*c) (see appendix A of E. Nagel et al. 2023, A&A, 680, A73)
+    S_star is the stellar template
+    func_IP is the function of the IP (one of the many defined above)
+    T_cell_atm is the transmission of the cell multiplied by transmission of the atmosphere
     '''
     if not tpl_IP_isconv:   # if tpl not convolved with IP : Apply regular convolution
         Sj_eff = np.convolve(func_IP, S_star * T_cell_atm, mode='valid')

--- a/utils/model.py
+++ b/utils/model.py
@@ -231,7 +231,6 @@ class model:
         for k, v in zip(varykeys, np.sqrt(np.diag(e_params))):
             pnew[k].unc = v
         if kwargs:
-            pass
             self.show(pnew, pixel, spec_obs, par_rv=pnew.rv, **kwargs)
         return pnew, e_params
 
@@ -247,7 +246,6 @@ class model:
         if x2 is None:
             x2 = np.poly1d(params.wave[::-1])(x-self.xcen)
         if par_rv:
-            pass
             gplot.RV2title(", v=%.2f ± %.2f m/s" % (par_rv*1000, par_rv.unc*1000))
         gplot.put("if (!exists('lam')) {lam=1}")
 

--- a/utils/model.py
+++ b/utils/model.py
@@ -133,7 +133,7 @@ def pade(x, a, b):
 
 
 
-def convolution(S_star, func_IP, T_cell_atm, tpl_IP_isconv=False, IP_hs=50):
+def convolution(S_star, func_IP, T_cell_atm, tpl_has_IP=False, IP_hs=50):
     '''
     Convolution with the IP as described in equation (7) of E. Koehler et al. 2025, A&A, 698, A44. 
     However : if star spectrum is already convolved with IP (true for SERVAL templates) : we do not want to convolve it again
@@ -142,13 +142,13 @@ def convolution(S_star, func_IP, T_cell_atm, tpl_IP_isconv=False, IP_hs=50):
     func_IP is the function of the IP (one of the many defined above)
     T_cell_atm is the transmission of the cell multiplied by transmission of the atmosphere
     '''
-    if not tpl_IP_isconv:   # if tpl not convolved with IP : Apply regular convolution
+    if not tpl_has_IP:   # if tpl not convolved with IP : Apply regular convolution
         Sj_eff = np.convolve(func_IP, S_star * T_cell_atm, mode='valid')
 
-    #if tpl already convolved with IP (eg. during template creation by coadding observation spectra): Take S_star out of convolution with IP 
-    elif tpl_IP_isconv: 
+    #but if tpl already convolved with IP (eg. during template creation by coadding observation spectra): Take S_star out of convolution with IP 
+    else: 
         Sj_eff = S_star[IP_hs:-IP_hs] * np.convolve(func_IP, T_cell_atm, mode='valid')
-        #the convolution np.conv(mode='valid') trims the edges of the largest array (removes as many data points as there are in the smallest array -- see numpy documentation). 
+        #convolution np.conv(mode='valid') trims edges of the largest array (removes as many data points as there are in the smallest array -- see np docs). 
         #here it trims [len(func_IP) = IP_hs] data points on either side of T_cell_atm (which has same length as S_star) : so we trim S_star the same way to be able to multiply it with the convolution
     
     return Sj_eff
@@ -159,7 +159,7 @@ class model:
     The forward model.
 
     '''
-    def __init__(self, *args, func_norm=poly, IP_hs=50, xcen=0, tpl_IP_isconv=False):
+    def __init__(self, *args, func_norm=poly, IP_hs=50, xcen=0, tpl_has_IP=False):
         # IP_hs: Half size of the IP (number of sampling knots).
         # xcen: Central pixel (to center polynomial for numeric reason).
         self.xcen = xcen
@@ -170,7 +170,7 @@ class model:
         self.vk = np.arange(-IP_hs, IP_hs+1) * self.dx * c    # position of sampling knots for the IP (expressed as speed)
         self.lnwave_j_eff = self.lnwave_j[IP_hs:-IP_hs]    # valid grid
         self.func_norm = func_norm
-        self.tpl_IP_isconv = tpl_IP_isconv
+        self.tpl_has_IP = tpl_has_IP
         #print("sampling [km/s]:", self.dx*c)
         
 
@@ -194,10 +194,10 @@ class model:
 
 
         # apply IP convolution
-        Sj_eff = convolution(S_star=self.S_star(self.lnwave_j-rv/c), func_IP=self.IP(self.vk, *coeff_ip), T_cell_atm=(spec_gas + coeff_bkg[0]), tpl_IP_isconv=self.tpl_IP_isconv, IP_hs=self.IP_hs)
+        Sj_eff = convolution(S_star=self.S_star(self.lnwave_j-rv/c), func_IP=self.IP(self.vk, *coeff_ip), T_cell_atm=(spec_gas + coeff_bkg[0]), tpl_has_IP=self.tpl_has_IP, IP_hs=self.IP_hs)
         if len(coeff_ipB):
             coeff_ipB = [coeff_ipB[0]*coeff_ip[0], *coeff_ip[1:]]
-            Sj_B =convolution(S_star=self.S_star(self.lnwave_j-rv/c), func_IP=self.IP(self.vk, *coeff_ipB), T_cell_atm=(spec_gas + coeff_bkg[0]), tpl_IP_isconv=self.tpl_IP_isconv, IP_hs=self.IP_hs)
+            Sj_B = convolution(S_star=self.S_star(self.lnwave_j-rv/c), func_IP=self.IP(self.vk, *coeff_ipB), T_cell_atm=(spec_gas + coeff_bkg[0]), tpl_has_IP=self.tpl_has_IP, IP_hs=self.IP_hs)
             Sj_A = Sj_eff
             g = self.lnwave_j_eff - self.lnwave_j_eff[0]
             g /= g[-1]

--- a/viper.py
+++ b/viper.py
@@ -288,6 +288,7 @@ def fit_chunk(order, chunk, obsname, targ=None, tpltarg=None):
 
     modset['xcen'] = xcen = np.nanmean(pixel_ok) + 18   # slight offset, then it converges for CES+TauCet
     modset['IP_hs'] = iphs
+    modset['tpl_IP_isconv'] = inst    # True or False : template is already convolved with IP (True for SERVAL templates which come from coadded observations)
 
     if deg_norm_rat:
         # rational polynomial

--- a/viper.py
+++ b/viper.py
@@ -285,7 +285,8 @@ def fit_chunk(order, chunk, obsname, targ=None, tpltarg=None):
 
     modset['xcen'] = xcen = np.nanmean(pixel_ok) + 18   # slight offset, then it converges for CES+TauCet
     modset['IP_hs'] = iphs
-    modset['tpl_IP_isconv'] = Inst.tpl_IP_isconv    # True or False : template is already convolved with IP       
+    read_tpl = importlib.import_module('inst.template')
+    modset['tpl_has_IP'] = getattr(read_tpl, 'tpl_has_IP', False)    # True or False : template is already convolved with IP (Returns False by default)   
 
     if deg_norm_rat:
         # rational polynomial

--- a/viper.py
+++ b/viper.py
@@ -32,7 +32,6 @@ try:
 except: 
     import vpr
 
-
 viperdir = os.path.dirname(os.path.realpath(__file__)) + os.sep
 
 c = 299792.458   # [km/s] speed of light
@@ -234,14 +233,13 @@ if __name__ == "__main__" or __name__ == "viper.viper":
 def fit_chunk(order, chunk, obsname, targ=None, tpltarg=None):
     ####  observation  ####
     pixel, wave_obs, spec_obs, err_obs, flag_obs, bjd, berv = Spectrum(obsname, order=order, targ=targ)
-    
     if telluric == 'mask':
         flag_obs[mskatm(wave_obs) > 0.1] |= flag.atm
     flag_obs[np.isnan(spec_obs)] |= flag.nan
 
     # select common wavelength range
-    lmin = max(wave_obs[iset][0], wave_tpl[order][0], wave_cell[0])
-    lmax = min(wave_obs[iset][-1], wave_tpl[order][-1], wave_cell[-1])
+    lmin = max(wave_obs[iset][0], wave_tpl[order][0], wave_cell[0])     # set the lower limit : the highest of the min wavelengths from obs, tpl, cell
+    lmax = min(wave_obs[iset][-1], wave_tpl[order][-1], wave_cell[-1])  # set the upper limit : the lowest of the max wavelengths from obs, tpl, cell
 
     # trim the observation to a range valid for the model
     #  vcut = 100   # [km/s]
@@ -253,7 +251,7 @@ def fit_chunk(order, chunk, obsname, targ=None, tpltarg=None):
     lnwave_j = lnwave_j_full[sj]
     spec_cell_j = spec_cell_j_full[sj]
 
-    ibeg, iend = np.where(flag_obs==0)[0][[0, -1]]   # the first and last pixel that is not trimmed
+    ibeg, iend = np.where(flag_obs==0)[0][[0, -1]]   # ibeg, iend = first, last pixel that are not trimmed
     
     len_ch = int((iend-ibeg)/chunks)
     ibeg = ibeg + chunk*len_ch
@@ -262,7 +260,6 @@ def fit_chunk(order, chunk, obsname, targ=None, tpltarg=None):
         # divide dataset into chunks
         flag_obs[:ibeg] |= flag.chunk
         flag_obs[iend:] |= flag.chunk
-
     if flagfile:
         # clip selected pixel ranges in order          
         for msk_i in msk_o[msk_o.order==order]:
@@ -288,7 +285,7 @@ def fit_chunk(order, chunk, obsname, targ=None, tpltarg=None):
 
     modset['xcen'] = xcen = np.nanmean(pixel_ok) + 18   # slight offset, then it converges for CES+TauCet
     modset['IP_hs'] = iphs
-    modset['tpl_IP_isconv'] = inst    # True or False : template is already convolved with IP (True for SERVAL templates which come from coadded observations)
+    modset['tpl_IP_isconv'] = Inst.tpl_IP_isconv    # True or False : template is already convolved with IP       
 
     if deg_norm_rat:
         # rational polynomial
@@ -333,7 +330,7 @@ def fit_chunk(order, chunk, obsname, targ=None, tpltarg=None):
         # add parameter for telluric position shift if selected
         if tellshift:
             par_atm.append((1, np.inf))
-
+            
     if demo & 1:
         # pre-look raw input
         # plot data, template, iodine, and tellurics with some scaling
@@ -353,7 +350,6 @@ def fit_chunk(order, chunk, obsname, targ=None, tpltarg=None):
         
         pause('demo 1: raw input')
 
-
     # convert discrete template into a function
     if tplname:
         S_star = lambda x: np.interp(x, np.log(wave_tpl[order]) - np.log(1+berv/c), spec_tpl[order])  # Apply barycentric motion
@@ -369,7 +365,7 @@ def fit_chunk(order, chunk, obsname, targ=None, tpltarg=None):
         # plot the IP
         gplot.xlabel('"[km/s]"')
         gplot.ylabel('"contribution"')
-        gplot(S_mod.vk, S_mod.IP(S_mod.vk), 't "IP model"')
+        gplot(S_mod.vk, S_mod.IP(S_mod.vk, *ip_guess), 't "IP model"')
         pause('demo 2: default IP')
 
     if demo & 4:
@@ -482,9 +478,9 @@ def fit_chunk(order, chunk, obsname, targ=None, tpltarg=None):
 
 
     if kapsig[0]:
-        # first kappa sigma clipping of outliers
+        # first kappa sigma clipping of outliers (clip data points whose residuals are too high compared to user-defined kapsig)
         smod = S_mod(pixel, **par3)
-        resid = spec_obs - smod
+        resid = spec_obs - smod    # diff between flux obs data and model
         resid[flag_obs != 0] = np.nan
 
         flag_obs[abs(resid) >= (kapsig[0]*np.nanstd(resid))] |= flag.clip
@@ -533,7 +529,7 @@ def fit_chunk(order, chunk, obsname, targ=None, tpltarg=None):
     show = (order in look) or (order in lookfast)
 
     if 1:
-        # par from prefit, (not pre-clip)
+        # par from prefit, (not pre-clipfixed)
         par.wave = parguess.wave   # why?
         # fix wavelength solution for stabilzied spectographs:
         if 'wave' in fix: par.wave = fixed(parguess.wave)
@@ -546,9 +542,9 @@ def fit_chunk(order, chunk, obsname, targ=None, tpltarg=None):
 
         par4, e_params = S_mod.fit(pixel_ok, spec_obs_ok, par, dx=0.1*show, sig=sig[i_ok], res=(not createtpl)*show, rel_fac=createtpl*show)
         par = par4
-
+        
     if kapsig[-1]:
-        # second kappa sigma clipping of outliers
+        # second kappa sigma clipping of outliers (clip data point if its residuals are too high)
         smod = S_mod(pixel, **par)
         resid = spec_obs - smod
         resid[flag_obs != 0] = np.nan
@@ -556,8 +552,8 @@ def fit_chunk(order, chunk, obsname, targ=None, tpltarg=None):
         nr_k1 = np.count_nonzero(flag_obs)
         flag_obs[abs(resid) >= (kapsig[-1]*np.nanstd(resid))] |= flag.clip
         nr_k2 = np.count_nonzero(flag_obs)
-
-        # test if outliers were flagged
+        
+        # test if outliers were flagged in the second clipping, and if flagged then remove them from pixel_ok
         if nr_k1 != nr_k2:
             i_ok = np.where(flag_obs == 0)[0]
             pixel_ok = pixel[i_ok]
@@ -579,11 +575,11 @@ def fit_chunk(order, chunk, obsname, targ=None, tpltarg=None):
                 sig /= np.nanmedian(sig[i_ok])
                 # down-weigth saturated lines
                 sig[spec_obs/np.nanmedian(spec_obs[i_ok])<0.1] = 2
-
+        
         if (nr_k1 != nr_k2) or ('tell' in wgt):
             par5, e_params = S_mod.fit(pixel_ok, spec_obs_ok, par3, dx=0.1*show, sig=sig[i_ok], res=(not createtpl)*show, rel_fac=createtpl*show)
             par = par5
-       
+        
     if createtpl:
         if tplname:
             # model just the tellurics; exclude stellar lines
@@ -676,7 +672,7 @@ def fit_chunk(order, chunk, obsname, targ=None, tpltarg=None):
     # overplot stellar spectrum
     #gplot+(np.exp(lnwave_j), S_star(lnwave_j)/S_star(lnwave_j).max()*spec_obs_ok.max(), 'w l lc 9')
 
-    rvo, e_rvo = 1000*par.rv, 1000*par.rv.unc   # convert to m/s
+    rvo, e_rvo = 1000*par.rv, 1000*par.rv.unc   # convert rv and rv uncertainty to m/s
     #prms = S_mod.show([params[0], params[1:1+1+deg_norm], params[2+deg_norm:2+deg_norm+1+deg_wave], params[3+deg_norm+deg_wave:]], pixel_ok, spec_obs_ok, dx=0.1)
     # gplot+(wave_tpl[s_s]*(1-berv/c), spec_tpl[s_s]*parguess_norm, 'w lp lc 4 ps 0.5')
     #gplot+(pixel_ok, S_star(np.log(np.poly1d(b[::-1])(pixel_ok))+(v)/c), 'w lp ps 0.5')
@@ -703,9 +699,9 @@ def fit_chunk(order, chunk, obsname, targ=None, tpltarg=None):
         pause(f'lookres {o}')
 
     if order in lookpar:   
-        sa = tplname is not None
-        sb = sa + deg_norm+1
-        ss = sb + deg_wave+1
+        sa = tplname is not None    # slice a (=1 if template was given, =0 otherwise)
+        sb = sa + deg_norm+1    # slice b : increase slice size to include poly coeffs in norm params (as many as deg_norm)
+        ss = sb + deg_wave+1    # slice s increase slice size to include poly coeffs in par.wave (as many as deg_wave)
         # error estimation
         # uncertainty in continuum
         xl = np.log(np.poly1d(par.wave[::-1])(pixel-xcen))
@@ -738,10 +734,11 @@ def fit_chunk(order, chunk, obsname, targ=None, tpltarg=None):
               'lc 3 ps 0.5 t "IP", "" us 1:3:4 w filledcurves fill fs transparent solid 0.2 lc 3 t "1{/Symbol s}"')
         gplot.unset('multiplot')
         pause('lookpar', par.ip)
-
+        
     return rvo, e_rvo, bjd.jd, berv, par, e_params, prms
 
 
+# gather the data files
 obsnames = np.array(sorted(glob.glob(obspath)))[nset]
 obsnames = [x for x in obsnames if not any(pat in os.path.basename(x) for pat in nexcl)]
 
@@ -754,6 +751,7 @@ if targname:
 orders = np.r_[oset]
 print(orders)
 
+# set up arrays for rv and e_rv (=rv uncertainty ); currently nan arrays, with one value per chunk for every order
 rv = np.nan * np.empty(chunks*len(orders))
 e_rv = np.nan * np.empty(chunks*len(orders))
 
@@ -769,8 +767,8 @@ print('BJD RV e_RV BERV', *map("rv{0} e_rv{0}".format, colnums), 'filename', fil
 pixel, wave0, spec0, err0, flag0, bjd, berv = Spectrum(obsnames[0], order=orders[0], targ=targ)
 pixel, wave1, spec1, err1, flag1, bjd, berv = Spectrum(obsnames[0], order=orders[-1], targ=targ)
     
-obs_lmin = np.min([wave0[0], wave0[-1], wave1[0], wave1[-1]])
-obs_lmax = np.max([wave0[0], wave0[-1], wave1[0], wave1[-1]])
+obs_lmin = np.min([wave0[0], wave0[-1], wave1[0], wave1[-1]])   # smallest wavelength in observation
+obs_lmax = np.max([wave0[0], wave0[-1], wave1[0], wave1[-1]])   # biggest wavelength in observation
 
 ####  FTS  ####
 # using the supersampled log(wavelength) space with knot index j
@@ -778,7 +776,7 @@ obs_lmax = np.max([wave0[0], wave0[-1], wave1[0], wave1[-1]])
 if ftsname != 'None':
     wave_cell, spec_cell, lnwave_j_full, spec_cell_j_full = FTS(ftsname)
 else:
-    # create fake cell spectrum 
+    # create fake cell spectrum (Has spectrum transmission = 1 through the entire observation wavelength range)
     wave_cell = np.linspace(obs_lmin, obs_lmax, len(pixel)*len(orders)*200)
     spec_cell = wave_cell*0 + 1
     u = np.log(wave_cell)
@@ -851,7 +849,7 @@ if tplname:
     print('reading stellar template')
     wave_tpl, spec_tpl = {}, {}
     for order in orders:
-        wave_tplo, spec_tplo = Tpl(tplname, order=order, targ=targ)
+        wave_tplo, spec_tplo  = Tpl(tplname, order=order, targ=targ)
         if oversampling:
             us = np.linspace(np.log(wave_tplo[0]), np.log(wave_tplo[-1]), oversampling*wave_tplo.size)
             spec_tplo = np.nan_to_num(spec_tplo)
@@ -902,15 +900,15 @@ for n, obsname in enumerate(obsnames):
             try:
                 gplot.RV2title = lambda x: gplot.key('title noenhanced "%s (n=%s, o=%s%s)"'% (filename, n+1, o, x))
                 gplot.RV2title('')
-        
+    
                 rv[i_o*chunks+ch], e_rv[i_o*chunks+ch], bjd, berv, params, e_params, prms = fit_chunk(o, ch, obsname=obsname, targ=targ)
-
                 print(n+1, o, ch, rv[i_o*chunks+ch], e_rv[i_o*chunks+ch])
                 # just for compability, remove Params(ipB=[]) later !!
                 if 'ipB' in params: params.pop('ipB')
                 if not deg_bkg: params.pop('bkg', None)                       
                 params.rv.value *= 1000.   # convert to m/s -> same unit in .par.dat and .rvo.dat     
                 params.rv.unc *= 1000.
+
 
                 if headrow:
                     headrow = False
@@ -927,14 +925,12 @@ for n, obsname in enumerate(obsnames):
                 if repr(e) == 'BdbQuit()':
                     exit()
                 print("Order failed due to:", repr(e))
-
     if not np.isnan(rv).all():
         oo = np.isfinite(e_rv)
         if oo.sum() == 1:
             RV = rv[oo][0]
             e_RV = e_rv[oo][0]
         else:
-            RV = np.nanmean(rv[oo])
             e_RV = np.nanstd(rv[oo])/(oo.sum()-1)**0.5
         print('RV:', RV, e_RV, bjd, berv)
 
@@ -942,6 +938,7 @@ for n, obsname in enumerate(obsnames):
         print(file=parunit)
 
 
+    elif np.isnan(rv).all():
 if createtpl:
     # combine all telluric corrected spectra to a final template
     wave_tpl_new = {}

--- a/viper.py
+++ b/viper.py
@@ -849,7 +849,7 @@ if tplname:
     print('reading stellar template')
     wave_tpl, spec_tpl = {}, {}
     for order in orders:
-        wave_tplo, spec_tplo  = Tpl(tplname, order=order, targ=targ)
+        wave_tplo, spec_tplo = Tpl(tplname, order=order, targ=targ)
         if oversampling:
             us = np.linspace(np.log(wave_tplo[0]), np.log(wave_tplo[-1]), oversampling*wave_tplo.size)
             spec_tplo = np.nan_to_num(spec_tplo)
@@ -931,6 +931,7 @@ for n, obsname in enumerate(obsnames):
             RV = rv[oo][0]
             e_RV = e_rv[oo][0]
         else:
+            RV = np.nanmean(rv[oo])
             e_RV = np.nanstd(rv[oo])/(oo.sum()-1)**0.5
         print('RV:', RV, e_RV, bjd, berv)
 
@@ -938,7 +939,6 @@ for n, obsname in enumerate(obsnames):
         print(file=parunit)
 
 
-    elif np.isnan(rv).all():
 if createtpl:
     # combine all telluric corrected spectra to a final template
     wave_tpl_new = {}


### PR DESCRIPTION
* Apply different convolution for templates that are already convolved with the IP

---> CARMENES (CARM_VIS and upcoming CARM_NIR) uses SERVAL templates which require a different convolution. The new convolution looks like it greatly improves RV precision for CARMENES when tellurics are present as opposed to the previous method. 
This also now allows us to use a proper `ip_guess` for CARMENES, whereas before we needed to make the IP guess very small in order to obtain coherent results.

---> For every instrument, added a global variable in the `Tpl()` function, called `tpl_IP_isconv` 
If template is already convolved with the IP, setting `tpl_IP_isconv` to True will apply a different convolution in `utils/model.py.` Setting it to False will not change anything.

`tpl_IP_isconv` is defined as "False" for every instrument, but it has been implemented in a way that this can easily be updated or added to new instruments if required.
For CARMENES, `tpl_IP_isconv` is linked to another variable called `tpl_is_serval,` which looks at the header for the template and checks whether or not a certain key `(HIERARCH SERVAL COADD NUM)` is present (Which I have tested to be present in every SERVAL template).

----> viper.py calls `Inst.tpl_IP_isconv` and assigns it to the already existing `modset`, which is used as an optional argument for the class model in `utils/model.py`

---> in `utils/model.py` : Defined a new function `convolution()` which applies the correct convolution method depending on whether the template is already convolved with the IP or not. Having this function allows to separate the two cases while keeping the code clean.
===> How and why this happens is explained with comments in the function


* in viper.py : When "plot IP" is selected, added the `ip_guess` as a parameter for the IP plot so that it is reflected in the plot.


* Updated CARM_VIS to include support for .fits templates from sources other than SERVAL
 ---> `tpl_is_serval` in the `Tpl()` function returns True or False by looking at the template header and checking if a certain keyword is contained (see the first point in this description). 
If True, apply the operations that are necessary for SERVAL templates (convert log wavelengths to linear, and apply cubic spline interpolation). 
If False, do not do these things.

* Updated CARM_VIS to include support for .all files (PEPSI templates) 
---> I have tried running viper with PEPSI template and the results were quite bad. I do not know if this is an issue with the code or something else, but I have moved on to something else and this may need to be looked into.


* Added comments in `viper.py` and `utils/model.py` in some places where I found it hard to understand what is happening. Also updated some comments in `inst/CARM_VIS.py` 
---> This may save some time for the next person who works on this