### PR TITLE
fix : RVs defaulting to last known value if order fails

### DIFF
--- a/viper.py
+++ b/viper.py
@@ -929,6 +929,7 @@ for n, obsname in enumerate(obsnames):
                 if repr(e) == 'BdbQuit()':
                     exit()
                 print("Order failed due to:", repr(e))
+                rv[i_o*chunks+ch], e_rv[i_o*chunks+ch] = np.nan, np.nan
 
     if not np.isnan(rv).all():
         oo = np.isfinite(e_rv)


### PR DESCRIPTION
If an order fails, the arrays `rv` and `e_rv` are not updated  and the RV for this order will default to the last known RV value.
This can impact the RV precision because of these "ghost" RVs.

This fix sets the `rv` and `e_rv` to a `nan`  for any order that fails. 