### PR TITLE
fix: nan values with "wmean" average type and ocen

### DIFF
--- a/vpr.py
+++ b/vpr.py
@@ -276,7 +276,7 @@ class VPR():
         gplot('for [n=1:N]', xpos, (A.rv-A.RV).T, self.e_rv.T,
             f'us ($1+{chksz}*n/N):(column(1+n)):(column(1+n+N)) w e pt 6 lc "light-grey" t "", ' +
             f'"" us ($1+{chksz}*n/N):(column(1+n)):(column(1+n+N)) w e pt 6 lc "red" t "RV_{{".n.",o}} -- RV_{{".n."}}",',
-            f'"" us ($1+{chksz}*n/N):(column(1+n)):'+'(sprintf("RV_{n=%d,o=%d} = %.2f ± %.2f m/s", n,$1, column(1+n), column(1+n+N))) w labels hypertext enh point pt 0 lc "red" t "",',
+            f'"" us ($1+{chksz}*n/N):(column(1+n)):'+'(sprintf("RV_{n=%d,o=%d} = %.2f ± %.2f m/s", n,$1+1, column(1+n), column(1+n+N))) w labels hypertext enh point pt 0 lc "red" t "",',
             f'"" us ($1+{chksz}*n/N):(column(1+n)-column(1+n+N)):'+'(sprintf("%.2f   ", column(1+n+N))) w labels noenh rotate right tc "red" t "",',  # red text
             A.BJD, A.RV+self.offset, A.e_RV, A.A.filename, ' us 1:2:(sprintf("%s\\nn: %d\\nBJD: %.6f\\nRV: %f ± %f",strcol(4),$0+1,$1,$2,$3)) w labels hypertext point pt 0 axis x2y1 t "",' +
             '"" us 1:2:3 w e lc "#77000000" pt 7 axis x2y1 t "RV_n",' +

--- a/vpr.py
+++ b/vpr.py
@@ -64,11 +64,7 @@ def average(yi, e_yi=None, typ='wmean', **kwargs):
         Y = np.nanmean(yi, **kwargs)
         e_Y = np.nanstd(yi, **kwargs) / (yi.size//Y.size-1)**0.5
     else:
-        y_isnan = np.isnan(yi)
-        yi[np.isnan(yi)] = 0
-        e_yi[np.isnan(e_yi)] = np.inf
-        Y, e_Y = wsem(yi, e=e_yi, **kwargs)
-        yi[y_isnan] = np.nan
+        Y, e_Y = wsem(np.nan_to_num(yi, nan=0), e=np.nan_to_num(e_yi, nan=np.inf), **kwargs)
     return Y, e_Y
 
 class VPR():

--- a/vpr.py
+++ b/vpr.py
@@ -64,9 +64,11 @@ def average(yi, e_yi=None, typ='wmean', **kwargs):
         Y = np.nanmean(yi, **kwargs)
         e_Y = np.nanstd(yi, **kwargs) / (yi.size//Y.size-1)**0.5
     else:
+        y_isnan = np.isnan(yi)
         yi[np.isnan(yi)] = 0
         e_yi[np.isnan(e_yi)] = np.inf
         Y, e_Y = wsem(yi, e=e_yi, **kwargs)
+        yi[y_isnan] = np.nan
     return Y, e_Y
 
 class VPR():
@@ -166,7 +168,7 @@ class VPR():
         self.info()
 
         if ocen:
-            RVo = np.mean(self.rv-self.RV, axis=1)
+            RVo = np.nanmean(self.rv-self.RV, axis=1)
             print('Subtracting mean order offsets from all RVs.')
             # This should not change the RV mean values (if unweighted).
             # The idea is to reduce RV uncertainty overestimation coming from large order offsets.
@@ -175,8 +177,8 @@ class VPR():
             self.RV, self.e_RV = average(self.rv, self.e_rv, axis=0, typ=self.avgtyp)
             self.info()
 
-        self.stat_o = np.percentile(self.rv-self.RV, [17,50,83], axis=1)
-        self.med_e_rvo = np.median(self.e_rv, axis=1)
+        self.stat_o = np.nanpercentile(self.rv-self.RV, [17,50,83], axis=1)
+        self.med_e_rvo = np.nanmedian(self.e_rv, axis=1)
 
     def plot_par(self, parcolx = None, parcoly = None):
 


### PR DESCRIPTION
Fix some visual bugs and ignore nan values when computing the "ocen" offset.

Some RVs which cannot be computed have nan values. Currently they are set to 0 in order to compute the weighted mean.
This is not the case if the "mean" average type is selected (non-weighted), which ignores nan values.

With this "fix" : 
* Sets the "nan" RVs back to nan values after computing the weighted mean. This prevents some computing errors later where these "nan" RVs were considered to have a value of 0 m/s. 
* nan RVs are not plotted in the "plot rv-o" mode. They used to be plotted and take the value of the average RV for each observation file.
* the "ocen" offset uses `np.nanmean`, `np.nanpercentile` and `np.nanmedian` to ignore nan values.
* Fix a visual bug in "plot o-rv" : hovering the cursor over the RVs for an order, used to show the wrong order.  (This is [fix: plot o-rv wrong order shown](https://github.com/mzechmeister/viper/commit/d16e59855414c87c20043db81a9a7a22a89ff321))


This pairs with pull request #59 which fixes an issue where orders that failed to be fitted, used to take whatever RV value was computed for the same order in the previous observation. Instead, it sets the RV for this "failed" order to nan.