### PR TITLE
quick fix: remove error message

### DIFF
--- a/vpr.py
+++ b/vpr.py
@@ -64,7 +64,7 @@ def average(yi, e_yi=None, typ='wmean', **kwargs):
         Y = np.nanmean(yi, **kwargs)
         e_Y = np.nanstd(yi, **kwargs) / (yi.size//Y.size-1)**0.5
     else:
-        Y, e_Y = wsem(np.nan_to_num(yi, nan=0), e=np.nan_to_num(e_yi, nan=np.inf), **kwargs)
+        Y, e_Y = wsem(np.nan_to_num(yi, nan=0, posinf=np.inf, neginf=-np.inf), e=np.nan_to_num(e_yi, nan=np.inf, posinf=np.inf, neginf=-np.inf), **kwargs)
     return Y, e_Y
 
 class VPR():


### PR DESCRIPTION
Since a previous pull request   (#60) `numpy.nan_to_num` also replaces `inf` and `-inf` with large finite numbers.
When the computed RV error is `inf`, this causes the apparition of the following error message (which does not impact the results in any way) :

>  /users/teriitehau/viper/utils/wstat.py:69: RuntimeWarning: overflow encountered in square
  w = np.ones_like(y) if e is None else 1./e**2


This "quick fix" removes the error message by telling `nan_to_num` not to replace `inf` values with large numbers. 