### PR TITLE
Change sign of tellshift to match similar variables

### DIFF
--- a/utils/model.py
+++ b/utils/model.py
@@ -163,16 +163,16 @@ class model:
 
             # variable telluric wavelength shift; one shift for all molecules
             if len(coeff_atm) == len(self.fluxes_molec)+1:
-                flux_atm = np.interp(self.lnwave_j, self.lnwave_j-np.log(1+coeff_atm[-1]/c), flux_atm)
+                flux_atm = np.interp(self.lnwave_j-np.log(1+coeff_atm[-1]/c), self.lnwave_j, flux_atm)
 
             spec_gas *= flux_atm
 
         # IP convolution
-        Sj_eff = np.convolve(self.IP(self.vk, *coeff_ip), self.S_star(self.lnwave_j-rv/c) * (spec_gas + coeff_bkg[0]), mode='valid')
+        Sj_eff = np.convolve(self.IP(self.vk, *coeff_ip), self.S_star(self.lnwave_j-np.log(1+rv/c)) * (spec_gas + coeff_bkg[0]), mode='valid')
 
         if len(coeff_ipB):
             coeff_ipB = [coeff_ipB[0]*coeff_ip[0], *coeff_ip[1:]]
-            Sj_B = np.convolve(self.IP(self.vk, *coeff_ipB), self.S_star(self.lnwave_j-rv/c) * (spec_gas + coeff_bkg[0]), mode='valid')
+            Sj_B = np.convolve(self.IP(self.vk, *coeff_ipB), self.S_star(self.lnwave_j-np.log(1+rv/c)) * (spec_gas + coeff_bkg[0]), mode='valid')
             Sj_A = Sj_eff
             g = self.lnwave_j_eff - self.lnwave_j_eff[0]
             g /= g[-1]


### PR DESCRIPTION
Change the sign of `tellshift` : A positive `tellshift` now corresponds to a redshifted observation, while in the previous implementation it corresponded to a blueshift.
This change makes the `tellshift` parameter use the same convention as the RV and instrument drift, where a positive value means means that the observation is redshifted.

In the images below, the telluric shift (orange) is influenced by the FP drift (blue), so they should have similar values.

**Current implementation** : The tellshift and the drift do not have the same sign : A positive drift means that the observation is redshifted, while a positive tellshift means that the observation is blueshifted.
<img width="1920" height="969" alt="tshift_bad" src="https://github.com/user-attachments/assets/beb72ad5-77db-4894-8a35-4c383b707ce3" />

**Proposed change :** After changing the sign of the tellshift, we can clearly see the correlation with the FP drift. This is the correct sign.
<img width="1920" height="969" alt="tshift_good" src="https://github.com/user-attachments/assets/de117413-21ef-45b7-b521-3f37377913ce" />

Also : When adding the RV to the stellar template, use `lnwave_j - ln(1+rv/c)` instead of the approximation `lnwave_j - rv/c`. 
This has no effect on precision, but it is more coherent with other parts of the code where the approximation `ln(1+x) ~= x` is not used.