### PR TITLE
Create new file for berv, drift, and other corrections

### DIFF
--- a/inst/correction.py
+++ b/inst/correction.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Mon May 25 16:34:59 2026
+This file was written by Naïm Teriitehau-Martin. For any issues, please contact : naimteriitehau@gmail.com 
+"""
+
+
+import numpy as np
+from astropy.io import fits
+from astropy.time import Time
+import astropy.units as u
+
+
+class correction:
+    def __init__(self, instfile, tpl, *args):
+
+        self.instfile = instfile
+        self.tpl = tpl
+        self.instname = self.instfile.__name__[10:]    # name of the inst file from inst.inst_NAME
+        
+
+    def berv(self, bjd, targ):
+        
+        inst_location = getattr(self.instfile, 'location', None)
+        
+        berv = targ.radial_velocity_correction(obstime=bjd, location=inst_location)  #Barycentric Earth RV : This is the RV correction to apply
+        
+        berv = berv.to_value(u.km/u.s)
+        
+        ## Could also be modified so that the berv correction is done here? and return the corrected wavelen instead
+            ### ---> take as input : lnwave_tpl = np.log(wave_tpl)
+            ### ==> then in viper.py when defining S_star just call : np.interp(x, correct.berv(np.log(wave_tpl[order]), bjd, targ), spec_tpl[order]) ?
+        #lnwave_tpl += np.log(1+ berv/c)
+        # return lnwave_tpl
+        
+        return berv
+    
+    
+    
+    
+    # For each instrument, define a function get_drift() which returns the drift and error
+    # Drift is applied directly to the RVs at the end, after fitting (for error propagation)
+    def drift(self, rv, e_rv, filename):
+
+        # if inst file has a function get_drift() that returns drift (e.g. from fits header)
+        try:
+            drift, e_drift = self.instfile.get_drift(filename=filename)    # this should only require filename and nothing else (order, targ, ...)?
+        except:
+            drift, e_drift = 0, 0
+        
+        rv -= drift
+        e_rv = np.sqrt(e_rv**2 + e_drift**2)
+        return rv, e_rv
+        
+        


### PR DESCRIPTION
Create a new file containing a class :  `correction` to apply barycentric correction to the template and drift correction.

An instance would be initialized in `viper.py` via : 
```
    from inst.correction import correction
    correct = correction(Inst, tplname)
```
with `Inst` and `tplname` already defined variables.

In its current state, the class could then be used to compute the barycentric correction from `viper.py` inside of the `fit_chunk` function, by calling `berv = correct.berv(bjd, targ)`, with `bjd` and `targ` already defined variables.
To compute the `berv`, `correct.berv` calls the `location` attribute from the relevant `Inst` file, then computes the `berv` the same way it is done in the current implementation, and finally returns the value `berv` [km/s] : 
```
        inst_location = getattr(self.instfile, 'location', None)
        berv = targ.radial_velocity_correction(obstime=bjd, location=inst_location)  
        berv = berv.to_value(u.km/u.s)
        return berv
```

The class can also apply the drift correction for an instrument directly to the RVs, by calling `rv, e_rv = correct.drift(rv, e_rv, obsname)`, with `obsname` an already defined variable.
To do so, `correct.drift` calls a function `get_drift(obsname)` which returns the drift and its error. This function needs to be defined directly in the relevant `Inst` file. If an `Inst` file does not have a `get_drift()` function, the drift is set to `0` : 
```
        try:
            drift, e_drift = self.instfile.get_drift(filename=filename)   
        except:
            drift, e_drift = 0, 0
```
Then the drift is added onto the RVs : 
```
        rv -= drift
        e_rv = np.sqrt(e_rv**2 + e_drift**2)
        return rv, e_rv
```
`correct.drift` is the main reason why I want to add the class `correction` in this new file, because it allows me to correct the drift for CARMENES without having to change other parts of the code in order to not break it. This class also makes it possible for other instruments to apply a similar drift correction if ever require it.
If this pull request is accepted, I plan to add to `drift.correct` so that, for CARMENES, the telluric shift can also be used to correct the drift of the instrument.


Secular acceleration is already corrected by `astropy`, but it is also possible to create another function `corect.sec_acc()` to "manually" correct for the secular acceleration using the formula from `targ.py` : 
```
      sec_acc = 22.98 * ((pmra/1000)**2+(pmde/1000)**2) / plx
```
but that is unnecessary.
