### PR TITLE
fix createtpl: a failed fitting breaks the code

### DIFF
--- a/viper.py
+++ b/viper.py
@@ -1013,12 +1013,12 @@ if createtpl:
         if (order in lookfast) or (order in look) or (order in lookctpl):
             gplot(wave_tpl_new[order], spec_tpl_new[order] - 1 , 'w l lc 7 t "combined tpl"')
             for n in range(len(spec_t)):
-                gplot+(wave_tpl_new[order], spec_t[n]/np.nanmedian(spec_t[n]), 'w l t "%s"' % (os.path.split(obsnames[n])[1]))          
+                gplot+(wave_tpl_new[order], spec_t[n]/np.nanmedian(spec_t[n]), 'w l t "%s"' % (os.path.split(obsnames_t[n])[1]))          
             #gplot+(wave_tpl_new[order], np.nanstd(spec_t, axis=0)+1.5, 'w l t ""')
         if (order in look) or (order in lookctpl):
             pause()
 
-    Inst.write_fits(wave_tpl_new, spec_tpl_new, err_tpl_new, obsnames, tag)
+    Inst.write_fits(wave_tpl_new, spec_tpl_new, err_tpl_new, obsnames_t, tag)
 
 rvounit.close()
 parunit.close()

--- a/viper.py
+++ b/viper.py
@@ -631,6 +631,7 @@ def fit_chunk(order, chunk, obsname, targ=None, tpltarg=None):
         spec_all[order, 0][n] = wave_model   # updated wavelength
         spec_all[order, 1][n] = spec_cor     # telluric corrected spectrum
         spec_all[order, 2][n] = weight       # weighting for combination of spectra
+        spec_all[order, 3][n] = obsname      # name of the file that will be coadded
 
     if show:
         # overplot flagged and clipped data
@@ -957,9 +958,12 @@ if createtpl:
         gplot.xlabel('"Vacuum wavelength [Å]"')
         gplot.ylabel('"flux"')
         gplot.yrange("[%g:%g]" % (-1, 1.6))
+        
         wave_t = np.array(list(spec_all[order, 0].values()))     # wavelength
         spec_t = np.array(list(spec_all[order, 1].values()))     # data
         weight_t = np.array(list(spec_all[order, 2].values()))   # weighting
+        obsnames_t = np.array(list(spec_all[order, 3].values())) # file name
+        
         weight_t[np.isnan(spec_t)] = 0
         weight_t[spec_t<0] = 0
         # weight_t[spec_t>1.15] = np.nanmin(weight_t)/10.
@@ -970,19 +974,29 @@ if createtpl:
 
         if len(spec_t) > 1:
             # combine several observations to one tpl
+            failed = []    # observations that failed to be fitted -- will not be coadded
             for nn in range(1, len(spec_t)):
-                # flag outlier points and spectra
-                valid = np.isfinite(spec_t[nn])
-                spec_cubic = CubicSpline(wave_t[nn][valid], spec_t[nn][valid])(wave_t[0])
-                spec_cubic[valid==0] = np.nan
-                spec_t[nn] = spec_cubic
+                try:
+                    # flag outlier points and spectra
+                    valid = np.isfinite(spec_t[nn])
+                    spec_cubic = CubicSpline(wave_t[nn][valid], spec_t[nn][valid])(wave_t[0])
+                    spec_cubic[valid==0] = np.nan
+                    spec_t[nn] = spec_cubic
+    
+                    # weight_cubic = CubicSpline(wave_t[nn][valid], weight_t[nn][valid])(wave_t[0])
+                    # weight_t[nn][valid] = weight_cubic[valid]
+                    weight_t[nn] = np.interp(wave_t[0], wave_t[nn][valid], weight_t[nn][valid])
+                    weight_t[nn][valid==0] = np.nan
+                    weight_t[nn][weight_t[nn]==0] = np.nan
+                except ValueError:
+                    # do not coadd the observation
+                    failed.append(nn)
 
-                # weight_cubic = CubicSpline(wave_t[nn][valid], weight_t[nn][valid])(wave_t[0])
-                # weight_t[nn][valid] = weight_cubic[valid]
-                weight_t[nn] = np.interp(wave_t[0], wave_t[nn][valid], weight_t[nn][valid])
-                weight_t[nn][valid==0] = np.nan
-                weight_t[nn][weight_t[nn]==0] = np.nan
-
+            spec_t = np.delete(spec_t, failed, axis=0)
+            wave_t = np.delete(wave_t, failed, axis=0)
+            weight_t = np.delete(weight_t, failed, axis=0)
+            obsnames_t = np.delete(obsnames_t, failed, axis=0)
+            
             if kapsig_ctpl:
               #  spec_mean = np.nansum(spec_t*weight_t, axis=0) / np.nansum(weight_t, axis=0)
                 spec_mean = np.nanmedian(spec_t, axis=0)


### PR DESCRIPTION
* Some observations can be fitted wrong, but still send data over to `spec_all`, the variable which contains wavelengths, flux and weighting data for template creation (See lines 631-634 of `viper.py` below) : 
```
        # save telluric corrected spectrum
        spec_all[order, 0][n] = wave_model   # updated wavelength
        spec_all[order, 1][n] = spec_cor     # telluric corrected spectrum
        spec_all[order, 2][n] = weight       # weighting for combination of spectra
```
`spec_cor` can be an array full of `nan` values, which is passed to `spec_all` anyway.


Later, during the co-adding of the spectra (Lines 975+ of `viper.py`), there is a check : `valid = np.isfinite(spec_t[nn])` which then returns an empty array if `spec_t[nn]` is full of `nan` values.
This causes a problem with the cubic spline (Line 976) : `spec_cubic = CubicSpline(wave_t[nn][valid], spec_t[nn][valid])(wave_t[0])` which fails and breaks the code, returning a `ValueError`

To fix this, I simply added a Try/Except which removes the observation that breaks the code (See lines 991-998 of the suggested change).


* Also : 
Template creation uses the variable `obsnames` to keep track of the different observations.
But if observation X fails and the data cannot be sent to `spec_all`, then the template will associate the wrong `obsname` for each spectrum.
For example, if we want co-add three spectra (number 0, 1, 2) for order 23 but observation number 1 fails to be fitted, then `spec_all` will have two values : `spec_all[order=23, :][n=0]` associated to spectrum number 0, and `spec_all[order=23, :][n=1]` associated to spectrum number 2.
But the variable `obsnames` will have three values : one for each spectrum, even the one that failed.
Because of this,  `spec_all[order=23, :][n=1]` (data from spectrum number 2) will be associated to `obsnames[n=1]` (data from spectrum 1).

To fix this, I also passed the `obsname` to `spec_all` along with the rest of the data (See line 634 of the suggested change) : 
`spec_all[order, 3][n] = obsname # name of the file that will be coadded`
Then created a new variable `obsnames_t` next to the others : 
```
        wave_t = np.array(list(spec_all[order, 0].values()))     # wavelength
        spec_t = np.array(list(spec_all[order, 1].values()))     # data
        weight_t = np.array(list(spec_all[order, 2].values()))   # weighting
        obsnames_t = np.array(list(spec_all[order, 3].values())) # file name
```
This variable contains only the name of observations that were successfully co-added.




