### PR TITLE
fix template.py : replace "or" with "and"

### DIFF
--- a/inst/template.py
+++ b/inst/template.py
@@ -49,7 +49,7 @@ def read_tpl(tplname, inst='inst_TLS.py', order=20, targ='None', wmin=3500, wmax
             inst = importlib.import_module('inst.'+str(inst)[:-3])
                        
             pixel, wave, spec, err, flag_pixel, bjd, berv = inst.Spectrum(tplname, order=order, targ=targ)
-            if not tplname.endswith('_tpl.model') or not tplname.endswith('_tpl.fits'):
+            if not tplname.endswith('_tpl.model') and not tplname.endswith('_tpl.fits'):
                 # apply barycentric correction
                 wave *= 1 + (berv*u.km/u.s/c).to_value('')
             successful_read = 1


### PR DESCRIPTION
Replace 
`
if not tplname.endswith('_tpl.model') or not tplname.endswith('_tpl.fits'):
` 
with
`
if not tplname.endswith('_tpl.model') and not tplname.endswith('_tpl.fits'):
`
(the **or** becomes **and**).

Otherwise, if `tplname` ends with **"_tpl.fits"**, the statement above returns `True` when it should return `False`.
This is because the statement (`True or False`) returns `True`. 

Here, we want to return `True` only if `tplname` does not end with  either **"_model.fits"** or **"_tpl.fits"**.

.

Also another issue :
The statement above is what decides if barycentric correction should be applied to the template.

If the statement is `True` (if `tplname` does not end with **"_model.fits"** and if it does not end with **"_tpl.fits"**) then we apply barycentric correction. (We assume that the template does not have barycentric correction applied)
If the statement is `False`  (if `tplname` ends with **"_model.fits"** or if it ends with **"_tpl.fits"**)  then we do not apply barycentric correction. (We assume that the template already has barycentric correction applied)

The problem is that viper can create a template that has barycentric correction applied (`tpl_wave` set to **berv**), or a template that does not have barycentric correction applied (`tpl_wave` set to **initial**). The name of the template `(tplname)` does not change depending on which option is chosen.
The statement above does not make a difference between these two, so one of them will be wrong depending on the name of the template.

What if instead, the chosen `tpl_wave` was inserted into the headers of the template, and instead of checking `tplname.endswith` to decide if viper should apply barycentric correction, we check the value of the `tpl_wave` header?
Something like : 
```
tpl_wave = hdr.get('TPL-WAVE', None)

if tpl_wave != 'BERV:
    # apply barycentric correction
```